### PR TITLE
Update docker-compose.yml to use the right qdrant health endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - roo-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6333/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:6333/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update qdrant health check endpoint to `/healthz` in `docker-compose.yml`.
> 
>   - **Health Check Update**:
>     - Change qdrant health check endpoint from `/health` to `/healthz` in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AIGeekSquad%2Froo-code-indexing&utm_source=github&utm_medium=referral)<sup> for 5eb0092f1873d425dd3633553c463d12b8eae815. You can [customize](https://app.ellipsis.dev/AIGeekSquad/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->